### PR TITLE
Prevent erroneous identification of a commit SHA as 6.c

### DIFF
--- a/Whateverable.pm6
+++ b/Whateverable.pm6
@@ -180,7 +180,7 @@ method get-commits($config) {
         @commits = $result.lines;
         my $num-commits = @commits.elems;
         return “Too many commits ($num-commits) in range, you're only allowed {COMMITS-LIMIT}” if $num-commits > COMMITS-LIMIT;
-    } elsif $config ~~ /:i releases | v? 6 \.? c / {
+    } elsif $config ~~ /:i releases | « v? 6 \.? c » / {
         @commits = self.get-tags('2015-12-25');
     } elsif $config ~~ /:i all / {
         @commits = self.get-tags('2014-01-01');


### PR DESCRIPTION
To prevent glitches like this: https://irclog.perlgeek.de/perl6/2016-12-20#i_13774319