### PR TITLE
Don't call 1 hour "a few moments"

### DIFF
--- a/lib/Misc.pm6
+++ b/lib/Misc.pm6
@@ -51,7 +51,10 @@ sub time-left(Instant() $then, :$already-there?) is export {
     my $time-left = $then - now;
     return $already-there if $already-there and $time-left < 0;
     my ($seconds, $minutes, $hours, $days) = $time-left.polymod: 60, 60, 24;
-    return ‘is just a few moments away’ if not $days and not $hours;
+    if not $days and not $hours {
+        return ‘is just a few moments away’ unless $minutes;
+        return “is in $minutes minute{‘s’ unless $minutes == 1}”;
+    }
     my $answer = ‘in ’;
     $answer ~= “$days day{$days ≠ 1 ?? ‘s’ !! ‘’} and ” if $days;
     $answer ~= “≈$hours hour{$hours ≠ 1 ?? ‘s’ !! ‘’}”;


### PR DESCRIPTION
- Return number of minutes until $then when it's just minutes
- Return 'a few moments' only when there is less than a minute left

Fixes #244