### PR TITLE
Evalable: respond to discord even if camelia is present

### DIFF
--- a/lib/Whateverable/Discordable.pm6
+++ b/lib/Whateverable/Discordable.pm6
@@ -14,12 +14,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use Whateverable::Bits;
 use IRC::Client::Message;
 
 my constant ChannelMessage = IRC::Client::Message::Privmsg::Channel;
 
 #| Transparently handle messages from the discord bridge.
 unit role Whateverable::Discordable;
+
+#| Role mixed into .nick of messages processed by Discordable
+my role FromDiscord is export { }
 
 #| Nick of the discord bridge bot.
 my constant DISCORD-BRIDGE = any(‘discord6’, ‘discord61’);
@@ -35,7 +39,7 @@ multi method irc-privmsg-channel(ChannelMessage $msg where .nick eq DISCORD-BRID
     # into $.nick. It is not used for routing the message on IRC, only to
     # address the user in the reply.
     my $bridged-msg = $msg.clone:
-        nick => ~$<nick>,
+        nick => ~$<nick> but FromDiscord,
         text => ~$<text>,
         args => [$msg.channel, ~$<text>],
     ;

--- a/xbin/Evalable.p6
+++ b/xbin/Evalable.p6
@@ -21,6 +21,7 @@ use Whateverable;
 use Whateverable::Bits;
 use Whateverable::Builds;
 use Whateverable::Config;
+use Whateverable::Discordable;
 use Whateverable::Processing;
 use Whateverable::Running;
 use Whateverable::Userlist;
@@ -35,8 +36,11 @@ method help($msg) {
 }
 
 multi method irc-to-me($msg) {
-    return self.process: $msg, $msg.text if $msg.args[1] !~~
-                                /^ \s*[master|rakudo|r|‘r-m’|m|p6|perl6]‘:’\s /;
+    # Do not answer when camelia is around (she reacts to the same triggers).
+    # But always do when the message is from discord because camelia doesn't
+    # support that.
+    return self.process: $msg, $msg.text if $msg.nick ~~ FromDiscord or
+            $msg.args[1] !~~ /^ \s*[master|rakudo|r|‘r-m’|m|p6|perl6]‘:’\s /;
     self.make-believe: $msg, (‘camelia’,), {
         self.process: $msg, $msg.text
     }

--- a/xt/evalable.t
+++ b/xt/evalable.t
@@ -185,8 +185,11 @@ start $camelia.run;
 sleep 1;
 
 for (‘’, ‘ ’) X~ (@alts X~ ‘: ’) {
-    $t.test(“camelia is back, be silent (‘$_’)”,
-            $_ ~ “say ‘$_’”)
+    $t.test(:!both, “camelia is back, be silent (‘$_’)”,
+            $_ ~ “say ‘$_’”);
+    $t.test(:!both, :bridge, “camelia is back, be NOT silent for discord (‘$_’)”,
+            $_ ~ “say ‘$_’”,
+            /^ <me($t)>‘, rakudo-moar ’<sha>“: OUTPUT: «$_␤»” $/)
 }
 
 for (‘’, ‘ ’) X~ (@alts X~ ‘:’) {


### PR DESCRIPTION
A follow-up to #357

Normally evalable6 leaves queries to camelia when she is around.
But camelia does not support responding to discord, so in that case
evalable6 should not restrain itself.

This is made possible by mixing a FromDiscord role into the nick
field of messages (not the message itself because that would break
event dispatch in IRC::Client) and testing for that while deciding
whether to leave the message to camelia or not.